### PR TITLE
Handle multi-project builds

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -70,7 +70,7 @@ class CoberturaExtension {
 	 * @param project the Gradle project that owns the extension.
 	 */
 	CoberturaExtension(Project project) {
-		println "Creating extension"
+		project.logger.info "creating extension"
 		this.project = project
 		coverageDirs = [ project.sourceSets.main.output.classesDir.path ]
 		coverageDatafile = new File("${project.buildDir.path}/cobertura", 'cobertura.ser')


### PR DESCRIPTION
The taskGraph.whenReady() is fired once for the entire project.  This patch prevents multiple whenReady() closures from being registered. Without the patch, an instance of the closure is registered as each subproject is configured causing it to run once for each subproject.  This causes the extension of the last project to be applied to every project and multiple afterTask() closures to be registered

Lacking a thorough understanding of gradle's internals, I set a gradle.ext property to indicate the whenReady() closure has been registered.  Seems like there ought to be a cleaner way of doing one-time  initialization, but I haven't worked it out..

thanks
-djs
