### PR TITLE
Fix InstrumentTask when having classesDirs set on Convention

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
@@ -33,7 +33,7 @@ class InstrumentTask extends DefaultTask {
 		// Before we instrument, copy from the main source to the instrumented path.
 		// Doing this here means we only need to do it when we need to instrument.
 		def instrumentDirs = [] as Set
-		project.files(project.sourceSets.main.output.classesDir.path).each { File f ->
+		project.files(classesDirs).each { File f ->
 			if (f.isDirectory()) {
 				// Copy directories from main source to instrumented path
 				project.copy {


### PR DESCRIPTION
For my multiproject setup I wanted to have one merged cobertura report.
Also when a TestClassX from module A covers code from module B, I want to have have the coverage beeing reported.
With my commit I evaluate the convention.coverageDirs property that holds a list of paths for my multiproject build.

build.gradle:

```
coverage {
       rootProject.subprojects.each {
            coverageDirs << file("subprojects/${it.name}/build/classes/main")
        }
```

This would help quite a few people I think. (Issue #6 addresses the same thing)
Maybe you can think about it.

Thanks,
detlef
