### PR TITLE
Fix ASM classloader conflicts.

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
@@ -82,17 +82,14 @@ class CoberturaPlugin implements Plugin<Project> {
 
 		CoberturaExtension extension = project.extensions.create('cobertura', CoberturaExtension, project)
 		if (!project.configurations.asMap['cobertura']) {
-			project.configurations.create('cobertura') {
-				extendsFrom project.configurations['testCompile']
-			}
+			project.configurations.create('cobertura')
 			project.afterEvaluate {
 				project.dependencies {
-					cobertura "net.sourceforge.cobertura:cobertura:${project.extensions.cobertura.coberturaVersion}"
+					cobertura("net.sourceforge.cobertura:cobertura:${project.extensions.cobertura.coberturaVersion}") {
+                        exclude group: 'log4j', module: 'log4j'
+                    }
 				}
 			}
-		}
-		project.afterEvaluate {
-			project.dependencies.add('testRuntime', "net.sourceforge.cobertura:cobertura:${project.extensions.cobertura.coberturaVersion}")
 		}
 
 		createTasks(project, extension)

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaRunner.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaRunner.groovy
@@ -1,10 +1,7 @@
 package net.saliman.gradle.plugin.cobertura
 
-import org.gradle.tooling.BuildException
-
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
-
 
 /**
  * Wrapper for Cobertura's main class.
@@ -151,7 +148,7 @@ public class CoberturaRunner {
 		}
 
 		def SecurityManager oldSm = System.getSecurityManager()
-		CoberturaSecurityManager sm = new CoberturaSecurityManager(oldSm);
+		CoberturaSecurityManager sm = new CoberturaSecurityManager(oldSm)
 
 		Class mainClass = cl.loadClass(className)
 		Method mainMethod = mainClass.getMethod("main", String[])


### PR DESCRIPTION
These has a couple pieces. First, the cobertura configuration no longer
extends testCompile. This is necessary because the cobertura files need
to be further isolated from what the project may be importing. Secondly,
we need to exclude the log4j jars from the configuration else we get
ClassLoader issues with the JCL classes. Basically, this amounts to all
JCL/Log4j files being loaded from the parent class loader instead of the
URLClassloader created to handle the cobertura configuration jars.
