### PR TITLE
Publish Cobertura report in buildDashboard

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.plugins.GroovyBasePlugin
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.plugins.scala.ScalaBasePlugin
 import org.gradle.api.tasks.testing.Test
 
@@ -81,6 +82,7 @@ class CoberturaPlugin implements Plugin<Project> {
 		// and Scala compiles to java classes under the hood, and the Groovy and
 		// Scala plugins will extend the Java plugin anyway.
 		project.plugins.apply(JavaPlugin)
+        project.plugins.apply(ReportingBasePlugin)
 
 		CoberturaExtension extension = project.extensions.create('cobertura', CoberturaExtension, project)
 		if (!project.configurations.asMap['cobertura']) {
@@ -190,6 +192,14 @@ class CoberturaPlugin implements Plugin<Project> {
 		generateReportTask.setDescription("Generate a Cobertura report after tests finish.")
 		generateReportTask.enabled = false
 		generateReportTask.runner = runner
+        generateReportTask.reports.all { report ->
+            report.conventionMapping.with {
+                enabled = true
+                destination = {
+                    new File(extension.coverageReportDir, "index.html")
+                }
+            }
+        }
 
 		// Create the performCoverageCheck task that will do the work of checking
 		// the coverage levels, and you guessed it, it is disabled.

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReports.java
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReports.java
@@ -1,0 +1,16 @@
+package net.saliman.gradle.plugin.cobertura;
+
+import org.gradle.api.reporting.ReportContainer;
+import org.gradle.api.reporting.SingleFileReport;
+
+/**
+ * The reporting configuration for the GenerateReportTask task.
+ */
+public interface CoberturaReports extends ReportContainer<SingleFileReport> {
+    /**
+     * The Cobertura html report
+     *
+     * @return The Cobertura text report
+     */
+    SingleFileReport getHtml();
+}

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
@@ -1,0 +1,20 @@
+package net.saliman.gradle.plugin.cobertura;
+
+import net.saliman.gradle.plugin.cobertura.CoberturaReports;
+import org.gradle.api.Task;
+import org.gradle.api.reporting.SingleFileReport;
+import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
+import org.gradle.api.reporting.internal.TaskReportContainer;
+
+public class CoberturaReportsImpl extends TaskReportContainer<SingleFileReport> implements CoberturaReports {
+
+    public CoberturaReportsImpl(Task task) {
+        super(SingleFileReport.class, task);
+
+        add(TaskGeneratedSingleFileReport.class, "html", task);
+    }
+
+    public SingleFileReport getHtml() {
+        return getByName("html");
+    }
+}

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
@@ -2,8 +2,12 @@ package net.saliman.gradle.plugin.cobertura
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
+import org.gradle.api.reporting.Reporting
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.reflect.Instantiator
+
+import javax.inject.Inject
 
 /**
  * Gradle task that does the actual work of generating the Cobertura coverage
@@ -17,11 +21,18 @@ import org.gradle.api.tasks.TaskAction
  * time (when it is enabled).  This is because while the code and tests may not
  * have changed, the actual tests run from build to build may have.
  */
-class GenerateReportTask extends DefaultTask {
+class GenerateReportTask extends DefaultTask implements Reporting<CoberturaReports> {
 	static final String NAME = 'generateCoberturaReport'
 	CoberturaExtension configuration
 	CoberturaRunner runner
 	Configuration classpath
+    @Nested
+    private final CoberturaReportsImpl reports
+
+    @Inject
+    GenerateReportTask(Instantiator instantiator) {
+        reports = instantiator.newInstance(CoberturaReportsImpl, this)
+    }
 
 	@TaskAction
 	def generateReports() {
@@ -43,4 +54,14 @@ class GenerateReportTask extends DefaultTask {
 							project.files(configuration.coverageSourceDirs).files.collect { it.path })
 		}
 	}
+
+    @Override
+    CoberturaReports getReports() {
+        reports
+    }
+
+    @Override
+    CoberturaReports reports(Closure closure) {
+        reports.configure(closure)
+    }
 }


### PR DESCRIPTION
Added ability to publish Cobertura report in the Gradle build dashboard. Example show here:
![builddashboardcobertura](https://f.cloud.github.com/assets/696855/2046905/90c07674-8a0e-11e3-96e3-f6116c9ad817.png)

Enhancement was developed together with @aalmiray during #hackergarten.
