### PR TITLE
Add auxiliaryClasspath configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ build.gradle file.  The cobertura block recognizes the following options:
 - ```coberturaVersion = <version>```: The version of Cobertura that will be
   used to run the coverage reports.  The default is 2.0.3.
 
+- ```auxiliaryClasspath = <FileCollection>```: You can set the classpath that 
+  Cobertura uses while instrumenting your classes. It defaults to 
+  project.sourceSets.main.output.classesDir +
+  project.sourceSets.main.compileClasspath
+  You can add to that easily
+  ```auxiliaryClasspath += files(configurations.examplesCompile.files)```
 
 - ```coverageDirs = [ <dirnames> ]```: An array of directories under the base directory
   containing classes to be instrumented.  The default is

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -1,6 +1,7 @@
 package net.saliman.gradle.plugin.cobertura
 
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.testing.Test
 
@@ -72,6 +73,14 @@ class CoberturaExtension {
 	 * List of ignore patterns
 	 */
 	List<String> coverageIgnores = []
+
+	/**
+	 * The classpath when instrumenting.
+	 * Defaults to 
+	 * project.sourceSets.main.output.classesDir,
+	 * project.sourceSets.main.compileClasspath,
+	 */
+	FileCollection auxiliaryClasspath
 
 	/**
 	 * Whether or not to ignore trivial methods like simple getters and setters.
@@ -201,6 +210,11 @@ class CoberturaExtension {
 		// groovy and scala plugins extend the java plugin.  This means that the
 		// java source directories will always be defined.
 		coverageSourceDirs = project.sourceSets.main.java.srcDirs
+
+		// Set the ausxiliaryClasspath to defaults. This is the classpath cobertura uses for
+		// resolving classes while instrumenting
+		auxiliaryClasspath = project.files project.sourceSets.main.output.classesDir
+		auxiliaryClasspath = auxiliaryClasspath.plus(project.sourceSets.main.compileClasspath)
 
 		// By default instrumentation depends on the "classes" task
 		coverageClassesTasksSpec = {

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
@@ -79,6 +79,15 @@ class InstrumentTask extends DefaultTask {
 	}
 
 	/**
+	 * If the auxiliary classpath changes, we'll need to
+	 * re-instrument.
+	 */
+	@InputFiles
+	def getAuxiliaryClasspath() {
+		configuration.auxiliaryClasspath
+	}
+
+	/**
 	 * The output file from this task is named inputDatafile because it is the
 	 * input input for the task that copies the ser file, and is input for the
 	 * tests.
@@ -123,26 +132,13 @@ class InstrumentTask extends DefaultTask {
 		// add the instrumented dir to the list.
 		instrumentDirs << ("${project.buildDir}/instrumented_classes" as String)
 
-		// set the auxiliary classpath to the current classpath plus jars in the
-		// lib dir plus classes in the output dir.
-		// AKA current classpath + compileClasspath + compileClassPath
-		//	    <path id="cobertura.auxpath">
-//	    <pathelement path="${classpath}"/>
-//	    <fileset dir="lib">
-//	    <include name="**/*.jar"/>
-//	    </fileset>
-//	    <pathelement location="classes"/>
-//	    </path>
-		String auxiliaryClasspath = project.sourceSets.main.output.classesDir.path +
-						File.pathSeparator + project.sourceSets.main.compileClasspath.getAsPath()
-
 		runner.withClasspath(classpath.files).instrument null, configuration.coverageInputDatafile.path, getDestinationDir()?.path,
 						configuration.coverageIgnores as List,
 						configuration.coverageIncludes as List,
 						configuration.coverageExcludes as List,
 						configuration.coverageIgnoreTrivial as boolean,
 						configuration.coverageIgnoreMethodAnnotations as List,
-						auxiliaryClasspath as String,
+						configuration.auxiliaryClasspath.getAsPath(),
 						instrumentDirs as List
 	}
 }

--- a/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtensionTest.groovy
+++ b/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtensionTest.groovy
@@ -404,4 +404,15 @@ class CoberturaExtensionTest {
 		]
 	}
 
+	/**
+	 * Try setting the to a file collection.
+	 * This should be fine.
+	 */
+	@Test
+	void setAuxiliaryClasspathValid() {
+		extension.auxiliaryClasspath = project.files('tmp')
+		assertEquals("Failed to set the auxiliaryClasspath", project.files('tmp'), extension.auxiliaryClasspath)
+	}
+
+
 }


### PR DESCRIPTION
With this option one can set the classpath Cobertura uses to find
classes while instrumenting
