### PR TITLE
Fix failing test for auxiliaryClasspath

### DIFF
--- a/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtensionTest.groovy
+++ b/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtensionTest.groovy
@@ -411,7 +411,7 @@ class CoberturaExtensionTest {
 	@Test
 	void setAuxiliaryClasspathValid() {
 		extension.auxiliaryClasspath = project.files('tmp')
-		assertEquals("Failed to set the auxiliaryClasspath", project.files('tmp'), extension.auxiliaryClasspath)
+		assertEquals("Failed to set the auxiliaryClasspath", project.files('tmp') as Set, extension.auxiliaryClasspath as Set)
 	}
 
 


### PR DESCRIPTION
The problem seems that although the file containers contain the same files
they do not provide the same hashCode(). This breaks equality. Converting the
contents of the lists into sets fixes the issue.