### PR TITLE
Fix broken unit test due to not initalizing coverageSourceDirs

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -221,6 +221,9 @@ class CoberturaExtension {
 		auxiliaryClasspath = auxiliaryClasspath.plus(project.sourceSets.main.compileClasspath)
 
 		coverageSourceDirs = project.sourceSets.main.java.srcDirs
+		if (project.plugins.hasPlugin('groovy')) {
+			coverageSourceDirs += project.sourceSets.main.groovy.srcDirs
+		}
 
 		// By default instrumentation depends on the "classes" task
 		coverageClassesTasksSpec = {

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -220,6 +220,8 @@ class CoberturaExtension {
 		auxiliaryClasspath = project.files project.sourceSets.main.output.classesDir
 		auxiliaryClasspath = auxiliaryClasspath.plus(project.sourceSets.main.compileClasspath)
 
+		coverageSourceDirs = project.sourceSets.main.java.srcDirs
+
 		// By default instrumentation depends on the "classes" task
 		coverageClassesTasksSpec = {
 			project.tasks.matching { it.name == 'classes' }

--- a/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPluginApplyTest.groovy
+++ b/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPluginApplyTest.groovy
@@ -177,6 +177,19 @@ class CoberturaPluginApplyTest {
 		assertTrue(configuration.coverageSourceDirs.asList().get(0).path.endsWith("src/main/java"))
 	}
 
+	@Test
+	void applyPluginConfigurationGroovyPluginSourceDirs() {
+		project.apply plugin: 'groovy'
+		project.apply plugin: 'cobertura'
+		CoberturaExtension configuration = project.extensions.getByName('cobertura')
+		assertNotNull("We're missing the configuration", configuration)
+		Set srcDirs = configuration.coverageSourceDirs
+		assertNotNull("We're missing the srcDirs", srcDirs)
+		assertEquals("Wrong number of srcDirs", 2, srcDirs.size())
+		assertTrue(configuration.coverageSourceDirs.asList().get(0).path.endsWith("src/main/java"))
+		assertTrue(configuration.coverageSourceDirs.asList().get(1).path.endsWith("src/main/groovy"))
+	}
+
 	/**
 	 * Helper method to make sure a task depends on another task.  This method
 	 * will fail a test if the given task does not depend on the given other task.


### PR DESCRIPTION
This change fixes the remaining broken unit test. The test in CoberturaExtensionExecutionTest still hang.