### PR TITLE
Add support for Android projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 
 // Release version that won't conflict with the bintray plugin
-def releaseVersion = "2.2.9-SNAPSHOT"
+def releaseVersion = "2.3.0-SNAPSHOT"
 // variables that configure the Maven upload
 group = "net.saliman"
 archivesBaseName = "gradle-cobertura-plugin"
@@ -81,7 +81,6 @@ signing {
 // Only *require* signing if we are uploading a non snapshot version.  If we
 // do need to sign, make sure we've got the properties we need to do the
 // signing.
-import org.gradle.plugins.signing.Sign
 gradle.taskGraph.whenReady { taskGraph ->
 	tasks.withType(org.gradle.plugins.signing.Sign).all {
 		required = taskGraph.hasTask(":uploadArchives") && !isSnapshot

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
@@ -80,19 +80,15 @@ class CoberturaPlugin implements Plugin<Project> {
 			project.afterEvaluate {
 				// When we're done evaluating, bring in the appropriate version of
 				// Cobertura.  Exclude logging dependencies because it causes conflicts
-				// with classes Gradle has already loaded.
+				// with classes Gradle has already loaded (on non android projects).
 				project.dependencies {
 					cobertura("net.sourceforge.cobertura:cobertura:${project.extensions.cobertura.coberturaVersion}") {
-						exclude group: 'log4j', module: 'log4j'
-						exclude group: 'org.slf4j', module: 'slf4j-api'
+						if (!isAndroidProject(project)) {
+							exclude group: 'log4j', module: 'log4j'
+							exclude group: 'org.slf4j', module: 'slf4j-api'
+						}
 					}
 				}
-			}
-		}
-
-		if (isAndroidProject(project)) {
-			project.dependencies {
-				testCompile "net.sourceforge.cobertura:cobertura:${extension.coberturaVersion}"
 			}
 		}
 

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
@@ -79,14 +79,17 @@ class GenerateReportTask extends DefaultTask implements Reporting<CoberturaRepor
 		}
 
 		Set<File> sourceDirs = configuration.coverageSourceDirs
-		if ( sourceDirs == null ) {
-			// The Java plugin is always applied.
-			sourceDirs = project.sourceSets.main.java.srcDirs
-			if ( project.sourceSets.main.hasProperty('groovy') ) {
-				sourceDirs += project.sourceSets.main.groovy.srcDirs
-			}
-			if ( project.sourceSets.main.hasProperty('scala') ) {
-				sourceDirs += project.sourceSets.main.scala.srcDirs
+		if (sourceDirs == null) {
+			if (CoberturaPlugin.isAndroidProject(project)) {
+				sourceDirs = project.android.sourceSets.main.java.srcDirs
+			} else {
+				sourceDirs = project.sourceSets.main.java.srcDirs
+				if (project.sourceSets.main.hasProperty('groovy')) {
+					sourceDirs += project.sourceSets.main.groovy.srcDirs
+				}
+				if (project.sourceSets.main.hasProperty('scala')) {
+					sourceDirs += project.sourceSets.main.scala.srcDirs
+				}
 			}
 		}
 		project.logger.info("${path} - Generating reports...")

--- a/usage.md
+++ b/usage.md
@@ -5,7 +5,7 @@ build.gradle file.
 
 ```groovy
 plugins {
-  id 'net.saliman.cobertura' version '2.2.7'
+  id 'net.saliman.cobertura' version '2.3.0-SNAPSHOT'
 }
 ```
 
@@ -17,7 +17,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "net.saliman:gradle-cobertura-plugin:2.2.7"
+        classpath "net.saliman:gradle-cobertura-plugin:2.3.0-SNAPSHOT"
     }
 }
 apply plugin: 'net.saliman.cobertura'
@@ -26,6 +26,8 @@ apply plugin: 'net.saliman.cobertura'
 If you are using Gradle 1.x, you will also need 
 ```classpath 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'``` in your
 build dependencies.
+
+If you are using the plugin on an android project, apply it after the android plugin.
 
 Tasks
 =====
@@ -217,3 +219,6 @@ following options:
   Defaults to project.buildDir.path/cobertura/cobertura.ser. The only time this
   should be changed is when users are merging datafiles and
   ```coverageMergeDatafiles``` contains the default datafile.
+
+- ```androidVariant = <String>```: The variant for android projects. The default is `debug`.
+  Running cobertura is only supported on a single test variant.


### PR DESCRIPTION
This adds support for Android projects by correctly referencing the
sources/classes directory for android libraries and applications.

If no android plugin was found on the project, the existing java project
path is followed. This currently allows for reporting code coverage on a
single android application/library variant (configurable via the
extension). Currently only supports unit tests, but can be extended easily
to support android instrumentation tests as well. Tested against
Robolectric version 3.0 and android gradle plugin 1.3.1.

Tested with
butterknife: https://github.com/kageiit/butterknife/tree/add_cobertura
deckard: https://github.com/kageiit/deckard-gradle/tree/add_cobertura

Fixes #82