### PR TITLE
compatibility android.tools.build.gradle v3 fix #141

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gradle-app.setting
 testclient/buildSrc/build
 testclient/buildSrc/.gradle
 *.bak
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 
 // Release version that won't conflict with the bintray plugin
-def releaseVersion = "2.5.1"
+def releaseVersion = "2.5.2"
 // variables that configure the Maven upload
 group = "net.saliman"
 archivesBaseName = "gradle-cobertura-plugin"

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -552,8 +552,13 @@ class CoberturaExtension {
 				auxiliaryClasspath = project.files("${project.buildDir.path}/intermediates/classes/${classesDir}")
 			}
 			coverageDirs = auxiliaryClasspath.asList()
-			auxiliaryClasspath = auxiliaryClasspath.plus(project.files(project.configurations.getByName("compile"),
-					project.configurations.getByName("${androidVariant}Compile")))
+
+			if (CoberturaPlugin.isAndroidToolsGradleVersion3(project)) {
+				auxiliaryClasspath = auxiliaryClasspath.plus(project.files(project.configurations.getByName("${androidVariant}CompileClasspath")))
+			} else {
+				auxiliaryClasspath = auxiliaryClasspath.plus(project.files(project.configurations.getByName("compile"),
+						project.configurations.getByName("${androidVariant}Compile")))
+			}
 		}
 		coverageSourceDirs = project.android.sourceSets.main.java.srcDirs
 


### PR DESCRIPTION
This PR allows to use the gradle-cobertura-plugin with android.build.tools:gradle:3.0.0 and previous versions.
I could not create the unit tests because I can not find a way to modify the buildscript.configuration.classpath in the tests.


