### PR TITLE
Android fix: rename isAndroidToolsVersion3() method to isAndroidToolsGradleVersion3()

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -556,8 +556,8 @@ class CoberturaExtension {
 			}
 			coverageDirs = auxiliaryClasspath.asList()
 
-			// Android Tools 3.0.0 doesn't need auxiliaryClasspath
-			if ( !CoberturaPlugin.isAndroidToolsVersion3(project) ) {
+			// Android Tools Gradle 3.0.0 doesn't need auxiliaryClasspath
+			if ( !CoberturaPlugin.isAndroidToolsGradleVersion3(project) ) {
 				auxiliaryClasspath = auxiliaryClasspath.plus(project.files(project.configurations.getByName("compile"),
 						project.configurations.getByName("${androidVariant}Compile")))
 			}

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPlugin.groovy
@@ -371,7 +371,7 @@ class CoberturaPlugin implements Plugin<PluginAware> {
 		return project.plugins.hasPlugin("kotlin-android")
 	}
 
-	static boolean isAndroidToolsVersion3(Project project) {
+	static boolean isAndroidToolsGradleVersion3(Project project) {
 		if ( !isAndroidProject(project) ) {
 			return false;
 		}


### PR DESCRIPTION
To avoid the following error:
```
    > No signature of method: static net.saliman.gradle.plugin.cobertura.CoberturaPlugin.isAndroidToolsGradleVersion3() is applicable for argument types: (org.gradle.api.internal.project.DefaultProject_Decorated)
```
as described in #146 