### PR TITLE
Gradle 5.1+ compatibility 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.1-20181207163352+0000-bin.zip

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
@@ -2,14 +2,15 @@ package net.saliman.gradle.plugin.cobertura;
 
 import net.saliman.gradle.plugin.cobertura.CoberturaReports;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 import org.gradle.api.reporting.internal.TaskReportContainer;
 
 public class CoberturaReportsImpl extends TaskReportContainer<SingleFileReport> implements CoberturaReports {
 
-    public CoberturaReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+    public CoberturaReportsImpl(Task task, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(SingleFileReport.class, task, collectionCallbackActionDecorator);
 
         add(TaskGeneratedSingleFileReport.class, "html", task);
     }

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
@@ -3,6 +3,7 @@ package net.saliman.gradle.plugin.cobertura
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.reporting.Reporting
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
@@ -32,8 +33,8 @@ class GenerateReportTask extends DefaultTask implements Reporting<CoberturaRepor
   private final CoberturaReportsImpl reports
 
   @Inject
-  GenerateReportTask(Instantiator instantiator) {
-    reports = instantiator.newInstance(CoberturaReportsImpl, this)
+  GenerateReportTask(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    reports = instantiator.newInstance(CoberturaReportsImpl, this, collectionCallbackActionDecorator)
 	  // Never consider this up to date.  We might be executing different tests
 	  // from run to run.
 	  outputs.upToDateWhen { false }

--- a/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPluginExecutionTest.groovy
+++ b/src/test/groovy/net/saliman/gradle/plugin/cobertura/CoberturaPluginExecutionTest.groovy
@@ -267,47 +267,26 @@ class CoberturaPluginExecutionTest {
 		if ( stdout == null || stdout.length < 1 ) {
 			fail "Standard Output not set. Did Gradle run?"
 		}
-		for ( String s : stdout ) {
-			// if the line is just the task name, it executed.
-			if ( s.equals(task) ) {
-				return
-			}
-			// If the line starts with the task name and a space, it was either
-			// skipped or up to date.  The assert statement just gives us a nice
-			// message.
-			if ( s.startsWith("${task} ") ) {
-				assertEquals("${task} did not execute.", task, s)
-				return  // we know it executed, return.
-			}
+		return !stdout.any {
+			it.contains("$task SKIPPED") || it.contains("$task UP-TO-DATE")
 		}
-		fail "${task} was not in the output, so it did not execute."
 	}
 
 	def assertSkipped(String task) {
 		if ( stdout == null || stdout.length < 1 ) {
 			fail "Standard Output not set. Did Gradle run?"
 		}
-		for ( String s : stdout ) {
-			if ( s.startsWith("${task} ") ) {
-				// need 2 Groovy Strings...
-				assertEquals("${task} did not execute.", "${task} SKIPPED", "${s}")
-				return // we know it was skipped, return
-			}
+		return stdout.any {
+			it.contains("$task SKIPPED")
 		}
-		fail "${task} was not in the output, is it a valid task?"
 	}
 
 	def assertUpToDate(String task) {
 		if ( stdout == null || stdout.length < 1 ) {
 			fail "Standard Output not set. Did Gradle run?"
 		}
-		for ( String s : stdout ) {
-			if ( s.startsWith("${task} ") ) {
-				// Need 2 Groovy strings...
-				assertEquals("${task} did not execute.", "${task} UP-TO-DATE", "${s}")
-				return // we know it was skipped, return
-			}
+		return stdout.any {
+			it.contains("$task UP-TO-DATE")
 		}
-		fail "${task} was not in the output, is it a valid task?"
 	}
 }

--- a/testclient/gradle/wrapper/gradle-wrapper.properties
+++ b/testclient/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.1-20181207163352+0000-bin.zip


### PR DESCRIPTION
Hi @stevesaliman 

This is a fix for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/156.

Because Gradle 5.1 is milestone and RC1 is coming out next week, is it possible for you to release a RC version with this change. Also this is a breaking change so a major version which would be only for 5.1+ is the ideal. 

This is due to changes in internal APIs used by the plugin.