### PR TITLE
Update plugin to support Gradle 6.x. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,11 +50,11 @@ repositories {
 }
 
 dependencies {
-	compile localGroovy()
-	compile gradleApi()
-	compile 'commons-io:commons-io:2.6'
-	testCompile 'junit:junit:4.12'
-	testRuntime 'net.sourceforge.cobertura:cobertura:2.1.1'
+	implementation localGroovy()
+	implementation gradleApi()
+	implementation 'commons-io:commons-io:2.6'
+	testImplementation 'junit:junit:4.12'
+	testRuntimeOnly 'net.sourceforge.cobertura:cobertura:2.1.1'
 //	archives "org.apache.maven.wagon:wagon-ssh:2.8"
 //	archives "org.apache.maven.wagon:wagon-ssh-external:2.8"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaExtension.groovy
@@ -10,7 +10,7 @@ import org.gradle.api.tasks.testing.Test
  * Extension class for configuring the Cobertura plugin.  Most of the properties
  * in this extension match options in Cobertura itself.
  */
-class CoberturaExtension {
+class CoberturaExtension  {
 	static ENCODING_UNDEFINED = 'undefined'
 
 	/**

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CoberturaReportsImpl.java
@@ -1,7 +1,7 @@
 package net.saliman.gradle.plugin.cobertura;
 
-import net.saliman.gradle.plugin.cobertura.CoberturaReports;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 import org.gradle.api.reporting.internal.TaskReportContainer;
@@ -9,8 +9,7 @@ import org.gradle.api.reporting.internal.TaskReportContainer;
 public class CoberturaReportsImpl extends TaskReportContainer<SingleFileReport> implements CoberturaReports {
 
     public CoberturaReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
-
+        super(SingleFileReport.class, task, CollectionCallbackActionDecorator.NOOP);
         add(TaskGeneratedSingleFileReport.class, "html", task);
     }
 

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/CopyDatafileTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/CopyDatafileTask.groovy
@@ -1,7 +1,9 @@
 package net.saliman.gradle.plugin.cobertura
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -22,6 +24,8 @@ import org.gradle.api.tasks.TaskAction
  */
 class CopyDatafileTask extends DefaultTask {
 	static final String NAME = 'copyCoberturaDatafile'
+
+	@Internal
 	CoberturaExtension configuration
 
 	/**

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/GenerateReportTask.groovy
@@ -4,7 +4,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.reporting.Reporting
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.reflect.Instantiator
@@ -26,8 +28,11 @@ import javax.inject.Inject
  */
 class GenerateReportTask extends DefaultTask implements Reporting<CoberturaReports> {
 	static final String NAME = 'generateCoberturaReport'
+	@Internal
 	CoberturaExtension configuration
+	@Internal
 	CoberturaRunner runner
+	@Classpath
 	Configuration classpath
   @Nested
   private final CoberturaReportsImpl reports
@@ -49,6 +54,7 @@ class GenerateReportTask extends DefaultTask implements Reporting<CoberturaRepor
 		})
 	}
 
+	@Internal
 	@Override
 	CoberturaReports getReports() {
 		reports

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/InstrumentTask.groovy
@@ -3,8 +3,10 @@ package net.saliman.gradle.plugin.cobertura
 import org.apache.commons.io.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -27,9 +29,13 @@ import static groovy.io.FileType.FILES
  */
 class InstrumentTask extends DefaultTask {
 	static final String NAME = 'instrument'
+	@Internal
 	File destinationDir
+	@Internal
 	CoberturaExtension configuration
+	@Internal
 	CoberturaRunner runner
+	@Classpath
 	Configuration classpath
 
 	/**

--- a/src/main/groovy/net/saliman/gradle/plugin/cobertura/PerformCoverageCheckTask.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/cobertura/PerformCoverageCheckTask.groovy
@@ -2,6 +2,9 @@ package net.saliman.gradle.plugin.cobertura
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.tooling.BuildException
 
@@ -19,10 +22,15 @@ import org.gradle.tooling.BuildException
  */
 class PerformCoverageCheckTask extends DefaultTask {
 	static final String NAME = 'performCoverageCheck'
+	@Internal
 	File destinationDir
+	@Internal
 	CoberturaExtension configuration
+	@Internal
 	CoberturaRunner runner
+	@Classpath
 	Configuration classpath
+	@Internal
 	boolean coverageCheckFailed = false
 
 	PerformCoverageCheckTask() {

--- a/testclient/gradle/wrapper/gradle-wrapper.properties
+++ b/testclient/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip


### PR DESCRIPTION
This is to support Gradle 6.x

Breaking change. 5.1+ is required because `TaskReportContainer` deprecated constructor was removed: https://github.com/gradle/gradle/commit/35f82562f772d1da9ef9344adbdcf70ee0e85ed4#diff-0028eb075660f7c3dd580a32070e4958

@stevesaliman 